### PR TITLE
Fix Python WhatsApp link and GDGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Se conheces uma comunidade não listada aqui, podes enviar um PR, que será de m
   <summary>Ver detalhes</summary>
   Vias de Comunicação
 
-  1. [Meetup (Maputo)](https://www.meetup.com/pt-BR/GDG-Maputo/)
-  2. [Meetup (Beira)](https://www.meetup.com/pt-BR/Beira-GDG/)
-  3. [Meetup (Tete)](https://www.meetup.com/pt-BR/GDG-TETE/)
+  1. [GDG Maputo](https://gdg.community.dev/gdg-maputo/)
+  2. [GDG Beira](https://gdg.community.dev/gdg-beira/)
+  3. [GDG Tete](https://gdg.community.dev/gdg-tete/)
   4. [Grupo do Facebook (Maputo)](https://pt-br.facebook.com/groups/gdgmaputo/)
   5. [Medium](https://medium.com/android-dev-moz)
 
@@ -136,7 +136,7 @@ Se conheces uma comunidade não listada aqui, podes enviar um PR, que será de m
   <summary>Ver detalhes</summary>
    Via de Comunicação
 
-1. [Whatsapp](https://chat.whatsapp.com/AtlP04I9rTL1GTbHPHKe3P)
+1. [Whatsapp](https://chat.whatsapp.com/Lqlzo70Im7B8DzXLWWFKsX)
 
 </details>
 


### PR DESCRIPTION
- the current Python WhatsApp link is no longer valid
- GDGs have moved from meetup.com to gdg.community.dev

Closes #15 